### PR TITLE
Add csound-watch plugin to the Risset index

### DIFF
--- a/rissetindex.json
+++ b/rissetindex.json
@@ -61,6 +61,9 @@
     },
     "semsys": {
       "url": "https://github.com/PasqualeMainolfi/csound-semsys.git"
+    },
+    "watch": {
+      "url": "https://github.com/PasqualeMainolfi/csound-watch.git"
     }
   }
 }


### PR DESCRIPTION
This PR adds the csound-watch plugin to the Risset plugin index.

# Csound Watch

Csound Watch is a Csound 7 plugin for real-time signal visualization. It
provides simple opcodes for creating oscilloscope, control-signal, spectrum,
spectrogram, static function-table, moving-point, and bar-meter windows while
keeping all graphics work outside Csound's audio thread.

## Features

- Oscilloscope-style visualization of a-rate signals.
- Time-domain visualization of k-rate control signals.
- Power-spectrum visualization of non-sliding PVS `f`-signals.
- Scrolling spectrograms from non-sliding PVS `f`-signals.
- Complete, init-time plotting of function tables.
- Moving points with a fading trail on a fixed, square plane.
- Multi-channel bar meters with peak hold and headroom above the range.
- Gain, power, and decibel spectral display scales.
- Several compatible streams in the same graph.
- Shared sample timeline for synchronized time-domain streams.
- Resizable windows with automatically generated axis and tick labels.
- Newly created graph windows are brought to the foreground.
- Per-graph light and dark themes with high-contrast stream colors.
- Automatic launch and shutdown of the standalone viewer.
- Support for several simultaneous Csound processes through one viewer.
- Portable local UDP transport for macOS, Linux, and Windows.
- No rendering, socket I/O, waiting, or viewer allocation in performance callbacks.

## Opcodes

| Opcode | Signal domain | Purpose |
|---|---|---|
| [`watchscope`](doc/watchscope.md) | Time | Create an oscilloscope graph |
| [`watchcontrol`](doc/watchcontrol.md) | Time | Create a control-signal graph |
| [`watchspectrum`](doc/watchspectrum.md) | Frequency | Create a power-spectrum graph |
| [`watchspectrogram`](doc/watchspectrogram.md) | Time/frequency | Create a scrolling spectrogram |
| [`watchtable`](doc/watchtable.md) | Table index | Plot a complete function table |
| [`watchpoint`](doc/watchpoint.md) | Plane | Create a fixed plane for moving points |
| [`watchmeter`](doc/watchmeter.md) | Level | Display an array of levels as a bar meter |
| [`watchtheme`](doc/watchtheme.md) | Graph appearance | Select the light or dark theme |
| [`watchadd`](doc/watchadd.md) | Any | Attach a signal or a coordinate pair to a graph |

## Technical specifications and limits

| Property | Value |
|---|---|
| Csound API | 7 |
| Network transport | UDP over loopback |
| Viewer endpoint | `127.0.0.1:48120` |
| Protocol version | 6 |
| Maximum graphs per Csound instance | 32 |
| Maximum open graphs in one viewer | 32 across all Csound sessions |
| Maximum streams per graph | 64 concurrent; a slot is released when the attaching instance ends |
| Audio samples per packet | Up to 256 |
| Control samples per packet | Up to 256 |
| Point samples per packet | Up to 128 (two interleaved floats each) |
| Point publishing cadence | `ceil(kr / 60)` points, one viewer frame |
| Point trail length | Approximately 100 ms, derived from `kr` |
| Meter channels per graph | Up to 32, set by the length of the levels array |
| Meter publishing cadence | One frame per viewer frame: `ceil(kr / 60)` control cycles reduced to their loudest value |
| Meter ballistics | Bar unsmoothed; peak held 1.5 s, then 1.0 s release |
| Meter headroom | One grid division above the declared maximum |
| Meter display latency | Up to one packet window plus one viewer frame, about 35 ms |
| Spectral bins per packet | Up to 256 |
| Function-table samples per packet | Up to 256 |
| Maximum function-table size | 1,073,741,824 samples (`Csound MAXLEN`) |
| Per-stream sender queue | 50 bounded slots |
| Viewer refresh rate | 60 Hz |
| Scope render latency | Approximately 50 ms |
| Control batching latency | Up to approximately `256 / kr` seconds |
| Default window size | 600 × 400 |
| Minimum window size | 360 × 260 |
| Default axis/grid divisions | 10 horizontal, 8 vertical |
| Maximum axis/grid divisions | 256 per axis; unrelated to sample or FFT-bin counts |
| Maximum title length | 383 bytes plus terminator |
| Spectral dB floor | `-160 dB` |

Large audio blocks, FFT frames, and function tables are divided across multiple
UDP packets. Control values are accumulated into batches of 256 samples.
Function-table packets carry their sample offset and transfer size; the viewer
displays the plot only after the transfer is complete.

The viewer validates packet magic, protocol version, type, payload length,
graph/stream identifiers, sample rate, FFT metadata, ranges, and title
termination before accepting data.